### PR TITLE
Configure cssmodules language server

### DIFF
--- a/kickstart/lua/plugins/lsp.lua
+++ b/kickstart/lua/plugins/lsp.lua
@@ -272,11 +272,11 @@ return {
 				},
 			})
 
-			local servers = {
-				copilot = {},
-				graphql = {},
-				sqlls = {},
-				lua_ls = {
+                        local servers = {
+                                copilot = {},
+                                graphql = {},
+                                sqlls = {},
+                                lua_ls = {
 					settings = {
 						Lua = {
 							diagnostics = {
@@ -311,14 +311,26 @@ return {
 						},
 					},
 				},
-				stylua = {},
-				lemminx = {},
-				xmlformatter = {},
-				beautysh = {},
-			}
+                                stylua = {},
+                                lemminx = {},
+                                xmlformatter = {},
+                                beautysh = {},
+                                cssmodules_ls = {
+                                        filetypes = {
+                                                "javascript",
+                                                "javascriptreact",
+                                                "typescript",
+                                                "typescriptreact",
+                                        },
+                                        init_options = {
+                                                -- Keep class name completion aligned with CSS dashes
+                                                camelCase = "dashes",
+                                        },
+                                },
+                        }
 
-			-- local ensure_installed = vim.tbl_keys(servers or {})
-			-- require("mason-tool-installer").setup({ ensure_installed = ensure_installed })
+                        local ensure_installed = vim.tbl_keys(servers or {})
+                        require("mason-tool-installer").setup({ ensure_installed = ensure_installed })
 
 			local capabilities = require("blink.cmp").get_lsp_capabilities()
 			for server, cfg in pairs(servers) do


### PR DESCRIPTION
## Summary
- add cssmodules_ls configuration for JavaScript and TypeScript React files, keeping CSS class completions dash-aligned
- ensure mason-tool-installer installs all configured language servers automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692905c509a48322874adcd561433a14)